### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/custom-callout/_schema.yml
+++ b/_extensions/custom-callout/_schema.yml
@@ -1,0 +1,32 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+options:
+  title:
+    type: string
+    description: "Default title for the custom callout (defaults to the capitalised type name)."
+  icon:
+    type: boolean
+    description: "Whether to show an icon in the callout header."
+  icon-symbol:
+    type: string
+    description: "Emoji or FontAwesome icon identifier (e.g., 'fa-star'). FontAwesome icons must start with 'fa-'."
+  color:
+    type: string
+    description: "Border and icon colour for the callout."
+    completion:
+      type: color
+  background-color:
+    type: string
+    description: "Background colour for the callout."
+    completion:
+      type: color
+  appearance:
+    type: string
+    enum:
+      - default
+      - simple
+      - minimal
+    description: "Visual style of the callout."
+  collapse:
+    type: boolean
+    description: "Whether the callout is collapsible."

--- a/_extensions/custom-callout/_snippets.json
+++ b/_extensions/custom-callout/_snippets.json
@@ -1,6 +1,6 @@
 {
   "Custom Callout Block": {
-    "prefix": "custom-callout",
+    "prefix": "callout",
     "body": [
       "::: {.${1:callout-type}}",
       "$0",
@@ -9,7 +9,7 @@
     "description": "Insert a custom callout block."
   },
   "Custom Callout with Title": {
-    "prefix": "custom-callout-title",
+    "prefix": "callout-title",
     "body": [
       "::: {.${1:callout-type}}",
       "",

--- a/_extensions/custom-callout/_snippets.json
+++ b/_extensions/custom-callout/_snippets.json
@@ -1,0 +1,24 @@
+{
+  "Custom Callout Block": {
+    "prefix": "custom-callout",
+    "body": [
+      "::: {.${1:callout-type}}",
+      "$0",
+      ":::"
+    ],
+    "description": "Insert a custom callout block."
+  },
+  "Custom Callout with Title": {
+    "prefix": "custom-callout-title",
+    "body": [
+      "::: {.${1:callout-type}}",
+      "",
+      "## ${2:Title}",
+      "",
+      "$0",
+      "",
+      ":::"
+    ],
+    "description": "Insert a custom callout block with a title."
+  }
+}


### PR DESCRIPTION
## Summary

- Add `_schema.yml` declaring options for custom callout definitions (`title`, `icon`, `icon-symbol`, `color`, `background-color`, `appearance`, `collapse`).
- Add `_snippets.json` with two snippets: custom callout block and custom callout with title.

> **Note:** This extension reads its configuration from the document-level `custom-callout` YAML key rather than from `extensions: custom-callout:`.
> Quarto Wizard currently assumes options are scoped under `extensions: <extension-name>:` to avoid conflicts with Quarto and other extensions.

## What is Quarto Wizard?

[Quarto Wizard](https://m.canouil.dev/quarto-wizard/dev/) is a VS Code extension that enhances the Quarto authoring experience with IDE tooling.
In its upcoming release, Quarto extensions will be able to contribute their own schema and snippets, which Quarto Wizard can use to provide autocompletion, validation, diagnostics, and snippet completion tailored to each extension.

Extensions opt in by shipping a `_schema.yml` file (declaring configurable options, shortcode parameters, element attributes, and CSS classes) and a `_snippets.json` file (VS Code-format snippets for common syntax patterns) alongside their `_extension.yml`.

- [Schema specification](https://m.canouil.dev/quarto-wizard/dev/reference/schema-specification.html)
- [Snippet specification](https://m.canouil.dev/quarto-wizard/dev/reference/snippet-specification.html)