### PR TITLE
Add RevealJS presentation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Quarto Callout with custom values such as its title, icon, icon symbol, color,
 appearance, and collapsibility.
 
 > [!IMPORTANT]
-> 
-> This extension is designed for Quarto HTML documents. 
+>
+> This extension supports Quarto HTML documents and RevealJS presentations.
 > We hope to extend this to other formats in the future.
 
 ## Installing

--- a/_extensions/custom-callout/customcallout.lua
+++ b/_extensions/custom-callout/customcallout.lua
@@ -34,6 +34,35 @@ local function colorToRgba(color, alpha)
   end
 end
 
+---CSS named color to hex lookup (without #, uppercase)
+---@type table<string, string>
+local cssNamedColors = {
+  -- CSS Level 1
+  black = "000000", silver = "C0C0C0", gray = "808080", white = "FFFFFF",
+  maroon = "800000", red = "FF0000", purple = "800080", fuchsia = "FF00FF",
+  green = "008000", lime = "00FF00", olive = "808000", yellow = "FFFF00",
+  navy = "000080", blue = "0000FF", teal = "008080", aqua = "00FFFF",
+  -- Extended common colors
+  orange = "FFA500", pink = "FFC0CB", brown = "A52A2A",
+  cyan = "00FFFF", grey = "808080",
+  crimson = "DC143C", coral = "FF7F50", gold = "FFD700",
+  indigo = "4B0082", violet = "EE82EE",
+  steelblue = "4682B4", dodgerblue = "1E90FF",
+  forestgreen = "228B22", tomato = "FF6347",
+  darkorange = "FF8C00", firebrick = "B22222",
+  slategray = "708090", darkred = "8B0000",
+}
+
+---Converts a color string to a 6-digit uppercase hex value (without #)
+---@param color string The color in hex (#RRGGBB) or named CSS format
+---@return string|nil hex The 6-digit hex string, or nil if conversion fails
+local function colorToHex(color)
+  if color:sub(1, 1) == "#" then
+    return color:sub(2):upper()
+  end
+  return cssNamedColors[color:lower()]
+end
+
 ---Adds HTML dependency for bundled FontAwesome 7 Free Solid font
 local function ensureFontAwesomeDeps()
   quarto.doc.add_html_dependency({
@@ -54,32 +83,40 @@ local function isFontAwesomeIcon(icon)
 end
 
 ---Generates CSS for all defined custom callouts
+---@param isRevealJS boolean Whether the output format is RevealJS
 ---@return string css The generated CSS rules
-local function generateCustomCSS()
+local function generateCustomCSS(isRevealJS)
   local css = ""
+  -- RevealJS uses `.reveal div.callout...` selectors with higher specificity,
+  -- so we need to match that prefix. It also uses `.callout-title` instead
+  -- of `.callout-header` for the header element.
+  local prefix = isRevealJS and ".reveal " or ""
+  local headerClass = isRevealJS and ".callout-title" or ".callout-header"
 
   -- Translate YAML callout information for custom callouts
   for type, callout in pairs(customCallouts) do
     if callout.color then
       local color = pandoc.utils.stringify(callout.color)
-      
+
       -- Base color
-      css = css .. string.format("div.callout-%s.callout {\n", type)
+      css = css .. string.format("%sdiv.callout-%s.callout {\n", prefix, type)
       css = css .. string.format("  border-left-color: %s;\n", color)
       css = css .. "}\n"
-      
+
       -- Header background
-      css = css .. string.format("div.callout-%s.callout-style-default > .callout-header {\n", type)
+      css = css .. string.format("%sdiv.callout-%s.callout-style-default %s {\n", prefix, type, headerClass)
       css = css .. string.format("  background-color: %s;\n", colorToRgba(color, 0.13))
       css = css .. "}\n"
 
-      -- Collapse Icon
-      css = css .. string.format("div.callout-%s .callout-toggle::before {", type)
-      css = css .. "  background-image: url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" fill=\"rgb(33, 37, 41)\" class=\"bi bi-chevron-down\" viewBox=\"0 0 16 16\"><path fill-rule=\"evenodd\" d=\"M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z\"/></svg>');"
-      css = css .. "}\n"
+      -- Collapse Icon (not supported in RevealJS)
+      if not isRevealJS then
+        css = css .. string.format("div.callout-%s .callout-toggle::before {", type)
+        css = css .. "  background-image: url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" fill=\"rgb(33, 37, 41)\" class=\"bi bi-chevron-down\" viewBox=\"0 0 16 16\"><path fill-rule=\"evenodd\" d=\"M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z\"/></svg>');"
+        css = css .. "}\n"
+      end
 
       -- Icon Styling
-      css = css .. string.format("div.callout-%s.callout-style-default .callout-icon::before, div.callout-%s.callout-titled .callout-icon::before {\n", type, type)
+      css = css .. string.format("%sdiv.callout-%s.callout-style-default .callout-icon::before, %sdiv.callout-%s.callout-titled .callout-icon::before {\n", prefix, type, prefix, type)
 
       if callout.icon_symbol then
         local icon_symbol_str = pandoc.utils.stringify(callout.icon_symbol)
@@ -89,16 +126,16 @@ local function generateCustomCSS()
           css = css .. "  font-weight: 900;\n"
           css = css .. "  font-style: normal;\n"
           css = css .. string.format("  content: '%s' !important;\n", fa.fa_unicode(icon_symbol_str))
-        else 
+        else
           -- Custom icon symbol
           css = css .. string.format("  content: '%s';\n", icon_symbol_str)
         end
         css = css .. "  background-image: none;\n"
-      else 
+      else
         -- The fallback case
         local escapedColor = color:gsub("#", "%%23")  -- Escape # in hex colors
         css = css .. string.format("  background-image: url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" fill=\"%s\" class=\"bi bi-exclamation-triangle\" viewBox=\"0 0 16 16\"><path d=\"M7.938 2.016A.13.13 0 0 1 8.002 2a.13.13 0 0 1 .063.016.146.146 0 0 1 .054.057l6.857 11.667c.036.06.035.124.002.183a.163.163 0 0 1-.054.06.116.116 0 0 1-.066.017H1.146a.115.115 0 0 1-.066-.017.163.163 0 0 1-.054-.06.176.176 0 0 1 .002-.183L7.884 2.073a.147.147 0 0 1 .054-.057zm1.044-.45a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566z\"/></svg>');\n", escapedColor)
-      end 
+      end
 
       css = css .. "}\n"
 
@@ -107,6 +144,46 @@ local function generateCustomCSS()
   return css
 end
 
+
+---Generates LaTeX \definecolor commands for PDF output
+---@return string latex The LaTeX color definitions
+local function generatePdfStyles()
+  local latex = ""
+  for type, callout in pairs(customCallouts) do
+    if callout.color then
+      local hex = colorToHex(pandoc.utils.stringify(callout.color))
+      if hex then
+        latex = latex .. string.format(
+          "\\definecolor{quarto-callout-%s-color}{HTML}{%s}\n", type, hex
+        )
+        latex = latex .. string.format(
+          "\\definecolor{quarto-callout-%s-color-frame}{HTML}{%s}\n", type, hex
+        )
+      end
+    end
+  end
+  return latex
+end
+
+---Generates Typst color definitions for Typst output
+---@return string typst The Typst style definitions
+local function generateTypstStyles()
+  local typst = ""
+  for type, callout in pairs(customCallouts) do
+    if callout.color then
+      local hex = colorToHex(pandoc.utils.stringify(callout.color))
+      if hex then
+        typst = typst .. string.format(
+          '#let quarto-callout-%s-color = rgb("#%s")\n', type, hex
+        )
+        typst = typst .. string.format(
+          '#let quarto-callout-%s-color-frame = rgb("#%s")\n', type, hex
+        )
+      end
+    end
+  end
+  return typst
+end
 
 ---Parses custom callout definitions from document metadata
 ---@param meta pandoc.Meta The document metadata
@@ -129,17 +206,29 @@ local function parseCustomCallouts(meta)
   end
 
 
-  -- Generate and add custom CSS to the document
-  local customCSS = generateCustomCSS()
-  if customCSS ~= "" then
-    quarto.doc.include_text('in-header', '<style>\n' .. customCSS .. '</style>')
-  end
-
-  -- Load FontAwesome font dependency if any callout uses FA icons (HTML only)
-  for _, callout in pairs(customCallouts) do
-    if callout.icon_symbol and isFontAwesomeIcon(pandoc.utils.stringify(callout.icon_symbol)) then
-      ensureFontAwesomeDeps()
-      break
+  -- Detect format and inject appropriate styles
+  local isRevealJS = quarto.doc.is_format("revealjs")
+  if quarto.doc.is_format("html") or isRevealJS then
+    local customCSS = generateCustomCSS(isRevealJS)
+    if customCSS ~= "" then
+      quarto.doc.include_text('in-header', '<style>\n' .. customCSS .. '</style>')
+    end
+    -- Load FontAwesome font dependency (HTML only)
+    for _, callout in pairs(customCallouts) do
+      if callout.icon_symbol and isFontAwesomeIcon(pandoc.utils.stringify(callout.icon_symbol)) then
+        ensureFontAwesomeDeps()
+        break
+      end
+    end
+  elseif quarto.doc.is_format("pdf") then
+    local pdfStyles = generatePdfStyles()
+    if pdfStyles ~= "" then
+      quarto.doc.include_text('in-header', pdfStyles)
+    end
+  elseif quarto.doc.is_format("typst") then
+    local typstStyles = generateTypstStyles()
+    if typstStyles ~= "" then
+      quarto.doc.include_text('in-header', typstStyles)
     end
   end
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -19,6 +19,8 @@ website:
         file: index.qmd
       - text: "Examples"
         file: qcustom-callout-example.qmd
+      - text: "RevealJS"
+        file: qcustom-callout-revealjs.qmd
       - section: "Support"
         contents:
         - text: "FAQ"

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -21,7 +21,7 @@ filters:
 ---
 
 The `{quarto-custom-callout}` extension enhances Quarto's built-in callout functionality by allowing you to
-create and use custom callouts in your Quarto documents. With this extension, you can define your 
+create and use custom callouts in your Quarto documents and RevealJS presentations. With this extension, you can define your
 own callout types with custom colors, icons, and appearances.
 
 ## Installation
@@ -100,4 +100,4 @@ Great job on completing this task!
 This is a custom 'todo' callout that is collapsible and has a custom title.
 :::
 
-For more detailed information on how to use and customize the `{quarto-custom-callout}` extension, please refer to our [Custom Callout Examples](qcustom-callout-example.qmd) or [FAQ](qcustom-callout-faq.qmd).
+For more detailed information on how to use and customize the `{quarto-custom-callout}` extension, please refer to our [Custom Callout Examples](qcustom-callout-example.qmd), [RevealJS](qcustom-callout-revealjs.qmd), or [FAQ](qcustom-callout-faq.qmd).

--- a/docs/qcustom-callout-example-revealjs.qmd
+++ b/docs/qcustom-callout-example-revealjs.qmd
@@ -1,0 +1,69 @@
+---
+title: "Custom Callout RevealJS Examples"
+format: revealjs
+
+custom-callout:
+  todo:
+    icon-symbol: "📝"
+    color: "pink"
+  jjb:
+    icon: true
+    title: "fix for JJB"
+    icon-symbol: "⚠️"
+    color: "#FFA500"
+  test:
+    title: "Test feature"
+    icon: true
+    color: "#801410"
+  thumbs-up:
+    title: "Great job!"
+    icon: true
+    icon-symbol: "fa-thumbs-up"
+    color: "#008000"
+filters:
+  - custom-callout
+---
+
+## Custom Callouts in RevealJS
+
+Custom callouts work in RevealJS presentations with full support for
+custom colors, emoji icons, and FontAwesome icons.
+
+::: todo
+Remember to complete this section.
+:::
+
+::: thumbs-up
+Great job on completing this task!
+:::
+
+## More Custom Callouts
+
+::: jjb
+Please address this issue ...
+:::
+
+::: test
+Let's do a feature test!
+:::
+
+## Custom Titles
+
+::: {.todo title="Todo with a Custom Title!"}
+Demo of `title="Todo with a Custom Title!"`.
+:::
+
+::: {.todo}
+## Todo with Title Defined in Content
+Demo of `title` defined as a markdown header in content.
+:::
+
+## Appearance Styles
+
+::: {.todo appearance="simple" title="Todo with Simple Appearance"}
+Demo of `appearance="simple"`.
+:::
+
+::: {.todo appearance="minimal" title="Todo with Minimal Appearance"}
+Demo of `appearance="minimal"`.
+:::

--- a/docs/qcustom-callout-example.qmd
+++ b/docs/qcustom-callout-example.qmd
@@ -24,7 +24,7 @@ filters:
   - custom-callout
 ---
 
-This document provides examples of custom callouts.
+This document provides examples of custom callouts in HTML format. For RevealJS presentation examples, see the [RevealJS](qcustom-callout-revealjs.qmd) page.
 
 ## Document YAML
 

--- a/docs/qcustom-callout-faq.qmd
+++ b/docs/qcustom-callout-faq.qmd
@@ -18,7 +18,7 @@ The custom-callout extension is a Quarto filter that allows you to create and us
 It extends the built-in callout functionality, enabling you to define your own callout types with custom colors, icons, and appearances.
 
 :::{.callout-important}
-The custom-callout extension only works with Quarto HTML documents currently. We're looking into expanding support for other output formats in the future.
+The custom-callout extension works with Quarto HTML documents and RevealJS presentations. We're looking into expanding support for other output formats in the future.
 :::
 
 ## How do I install the custom-callout extension?
@@ -152,8 +152,9 @@ Alternatively, you can add custom CSS to your document to override the default s
 
 ## Is this extension compatible with all Quarto output formats?
 
-The custom-callout extension is primarily designed for HTML output. While it may work with other formats to some extent, 
-the full range of customization options (especially custom icons and colors) might not be available in non-HTML outputs.
+The custom-callout extension supports HTML documents and RevealJS presentations. RevealJS has full support for custom colors, icons (emoji and FontAwesome), and appearance styles. Collapsible callouts are not supported in RevealJS due to the presentation format.
+
+Other output formats (PDF, Typst, DOCX) are not yet fully supported.
 
 
 ## How does the quarto-custom-callout extension compare to the quarto-custom-numbered-blocks extension?

--- a/docs/qcustom-callout-release-notes.qmd
+++ b/docs/qcustom-callout-release-notes.qmd
@@ -12,6 +12,7 @@ format:
 
 ## Features
 
+- Added RevealJS presentation support. Custom colors, emoji icons, FontAwesome icons, and appearance styles now work in `format: revealjs`. ([#15](https://github.com/coatless-quarto/custom-callout/issues/15))
 - Allow `title` to be specified as a markdown header in the callout's content.
 
 ````md

--- a/docs/qcustom-callout-revealjs.qmd
+++ b/docs/qcustom-callout-revealjs.qmd
@@ -1,0 +1,52 @@
+---
+title: "RevealJS Support"
+format:
+  html:
+    toc: true
+---
+
+The `{quarto-custom-callout}` extension works with [RevealJS](https://quarto.org/docs/presentations/revealjs/) presentations. Custom colors, emoji icons, FontAwesome icons, and appearance styles are all supported. Collapsible callouts are not available in RevealJS due to the nature of the presentation format. For more details on custom callout types in Quarto, see the [Quarto Callout Types documentation](https://quarto.org/docs/authoring/callouts.html#callout-types) and [quarto-dev/quarto-cli#1328](https://github.com/quarto-dev/quarto-cli/issues/1328).
+
+## Usage
+
+To use custom callouts in a RevealJS presentation, set `format: revealjs` and define your callouts under `custom-callout` as usual:
+
+````yaml
+---
+title: "My Presentation"
+format: revealjs
+custom-callout:
+  todo:
+    icon-symbol: "📝"
+    color: "pink"
+  thumbs-up:
+    title: "Great job!"
+    icon: true
+    icon-symbol: "fa-thumbs-up"
+    color: "#008000"
+filters:
+  - custom-callout
+---
+````
+
+Then use them in your slides:
+
+````md
+## Slide Title
+
+::: todo
+Remember to complete this section.
+:::
+
+::: thumbs-up
+Great job on completing this task!
+:::
+````
+
+## Live Example
+
+<a href="qcustom-callout-example-revealjs.html" target="_blank" rel="noopener">Open presentation in a new window &#x2197;</a>
+
+```{=html}
+<iframe class="slide-deck" src="qcustom-callout-example-revealjs.html" style="width: 100%; aspect-ratio: 1050/700; border: 1px solid #dee2e6; border-radius: 4px;"></iframe>
+```


### PR DESCRIPTION
Closes #15                                                                                                                                                                
                                                                            
RevealJS presentations now support custom callout colors, emoji icons, FontAwesome icons, and appearance styles. The CSS generation detects RevealJS and prefixes selectors with `.reveal` to override the theme's higher-specificity defaults, and targets `.callout-title` instead of `.callout-header` to match RevealJS's HTML structure. Collapsible callouts are skipped since RevealJS doesn't support them.

A dedicated RevealJS documentation page embeds a live example presentation via iframe with an option to open it in a new tab. The README, FAQ, examples page, and release notes have been updated to reflect multi-format support.